### PR TITLE
Using the Measurement API

### DIFF
--- a/Summits/Models/Summit.swift
+++ b/Summits/Models/Summit.swift
@@ -9,13 +9,59 @@ import Foundation
 
 
 struct Summit: Decodable, Identifiable, Equatable {
+    private let prominenceFt: Int
+    let elevationFt: Int
     let id: String
     let name: String
-    let elevationFt: Int
     let range: String
-    let prominenceFt: Int
     let geolocation: Geolocation
     let state: String
+    
+    var formattedElevation: String {
+        let measurement = Measurement(value: Double(elevationFt), unit: UnitLength.feet)
+        return measurement.formatted(.measurement(width: .abbreviated, usage: .asProvided))
+    }
+    
+    var formattedProminence: String {
+        let measurement = Measurement(value: Double(prominenceFt), unit: UnitLength.feet)
+        return measurement.formatted(.measurement(width: .abbreviated, usage: .asProvided))
+    }
+    
+    // MARK: - Initializer
+    
+    init(
+        id: String,
+        name: String,
+        elevationFt: Int,
+        range: String,
+        prominenceFt: Int,
+        geolocation: Geolocation,
+        state: String
+    ) {
+        self.id = id
+        self.name = name
+        self.elevationFt = elevationFt
+        self.range = range
+        self.prominenceFt = prominenceFt
+        self.geolocation = geolocation
+        self.state = state
+    }
+    
+    // MARK: - Mock Data
+    
+    static let washington = Summit(
+        id: "0",
+        name: "Washington",
+        elevationFt: 6288,
+        range: "Presidential Range",
+        prominenceFt: 6148,
+        geolocation: Geolocation(latitude: 44.2704, longitude: -71.3033),
+        state: "New Hampshire"
+    )
+    
+    static let summits: [Summit] = [.washington, .washington, .washington, .washington]
+ 
+    // MARK: - Equatable
     
     static func == (lhs: Summit, rhs: Summit) -> Bool {
         lhs.id == rhs.id
@@ -29,10 +75,4 @@ struct Geolocation: Decodable {
 
 struct SummitResponse: Decodable {
     let response: [Summit]
-}
-
-struct MockData {
-    static let sampleSummit = Summit(id: "0", name: "Washington", elevationFt: 6288, range: "Presidential Range", prominenceFt: 6148, geolocation: Geolocation(latitude: 44.2704, longitude: -71.3033), state: "New Hampshire")
-    
-    static let summits = [sampleSummit, sampleSummit, sampleSummit, sampleSummit]
 }

--- a/Summits/Screens/HikeLogView/HikeLogView.swift
+++ b/Summits/Screens/HikeLogView/HikeLogView.swift
@@ -158,10 +158,24 @@ struct HikeLogView: View {
 #Preview {
     NavigationStack {
         Text("")
-            .sheet(isPresented: .constant(true), content: {
-                HikeLogView(viewModel: HikeLogViewModel(), summit: MockData.sampleSummit, currentHike: Hike(summitID: "0", date: Date(), rating: 5, weather: "Sunny", companions: "", details: "Details", images: []), hikeLogVisible: .constant(true))
+            .sheet(
+                isPresented: .constant(true)) {
+                    HikeLogView(
+                        viewModel: HikeLogViewModel(),
+                        summit: .washington,
+                        currentHike: Hike(
+                            summitID: "0",
+                            date: Date(),
+                            rating: 5,
+                            weather: "Sunny",
+                            companions: "",
+                            details: "Details",
+                            images: []
+                        ),
+                        hikeLogVisible: .constant(true)
+                    )
                     .presentationDetents([.large])
-            })
+            }
     }
     .modelContainer(for: Hike.self)
 }

--- a/Summits/Screens/MapView/ActiveSummitView.swift
+++ b/Summits/Screens/MapView/ActiveSummitView.swift
@@ -44,7 +44,7 @@ struct ActiveSummitView: View {
             VStack(alignment: .leading){
                 Text(selectedSummit.name)
                     .font(.title2)
-                Text("\(selectedSummit.elevationFt) ft")
+                Text(selectedSummit.formattedElevation)
                     .font(.title3)
             }
             .padding(.leading, 10)

--- a/Summits/Screens/SummitDetailView/ElevationView.swift
+++ b/Summits/Screens/SummitDetailView/ElevationView.swift
@@ -16,7 +16,7 @@ struct ElevationView: View {
                 VStack {
                     Text("Elevation:")
                         .frame(maxWidth: .infinity, alignment: .leading)
-                    Text("\(summit.elevationFt) ft")
+                    Text(summit.formattedElevation)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .font(.title)
                 }
@@ -24,7 +24,7 @@ struct ElevationView: View {
                 VStack {
                     Text("Prominence:")
                         .frame(maxWidth: .infinity, alignment: .leading)
-                    Text("\(summit.prominenceFt) ft")
+                    Text(summit.formattedProminence)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .font(.title)
                 }

--- a/Summits/Screens/SummitDetailView/SummitDetailView.swift
+++ b/Summits/Screens/SummitDetailView/SummitDetailView.swift
@@ -123,7 +123,10 @@ struct SummitDetailView: View {
 
 #Preview {
     NavigationStack {
-        SummitDetailView(summit: MockData.sampleSummit, hikes: [])
+        SummitDetailView(
+            summit: .washington,
+            hikes: []
+        )
     }
     .modelContainer(for: Hike.self)
 }

--- a/Summits/Screens/SummitListView/SummitListCell.swift
+++ b/Summits/Screens/SummitListView/SummitListCell.swift
@@ -21,7 +21,7 @@ struct SummitListCell: View {
             VStack {
                 Image(systemName: "mountain.2")
                     .font(.system(size: 32))
-                Text("\(summit.elevationFt) ft")
+                Text(summit.formattedElevation)
                     .font(.system(size: 16, weight: .semibold))
             }
             
@@ -44,6 +44,10 @@ struct SummitListCell: View {
 
 struct SummitListCell_Previews: PreviewProvider {
     static var previews: some View {
-        SummitListCell(summit: MockData.sampleSummit, index: 0, hiked: true)
+        SummitListCell(
+            summit: .washington,
+            index: 0,
+            hiked: true
+        )
     }
 }


### PR DESCRIPTION
### Description
This PR refactors the code to replace hardcoded values in feet with Swift's Measurement type, specifically using UnitLength. This change enhances the code's flexibility and makes it easier to support different units of measurement in the future.

### Benefits
Improved Flexibility: By using Measurement, the code can easily handle other units of length (e.g., meters, inches) without requiring significant changes.
Increased Readability: Code now explicitly states the unit of measurement, making it clearer to developers.
Future-Proof: Easier to extend the functionality to support additional units of measurement if needed.

### Screenshots

![image](https://github.com/user-attachments/assets/8ca149a5-4beb-4ff2-8e8d-438708425cb0)
